### PR TITLE
repos: disallow wrong base

### DIFF
--- a/src/homebrew.rs
+++ b/src/homebrew.rs
@@ -84,7 +84,7 @@ impl SnapshotStorage<SnapshotPath> for Homebrew {
                 if url.starts_with(&bottles_base) {
                     url[bottles_base.len()..].to_string()
                 } else {
-                    panic!("unsupported homebrew base");
+                    panic!("Bottles URL doens't begin with its base: {:?}", url);
                 }
             })
             .map(|url| crate::utils::rewrite_url_string(&gen_map, &url))

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ fn main() {
         concurrent_transfer: opts.transfer_config.concurrent_transfer,
         no_delete: opts.transfer_config.no_delete,
         print_plan: opts.transfer_config.print_plan,
+        dry_run: opts.transfer_config.dry_run,
         snapshot_config,
     };
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -127,6 +127,8 @@ pub struct TransferConfig {
     pub concurrent_transfer: usize,
     #[structopt(long, help = "Don't delete files")]
     pub no_delete: bool,
+    #[structopt(long, help = "Enable dry run mode")]
+    pub dry_run: bool,
     #[structopt(
         long,
         help = "Print first n records of transfer plan",

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -126,9 +126,9 @@ impl SnapshotStorage<SnapshotPath> for Pypi {
         let snapshot = packages?
             .into_iter()
             .flatten()
-            .filter_map(|(url, _)| {
+            .map(|(url, _)| {
                 if url.starts_with(&package_base) {
-                    Some(url[package_base.len()..].to_string())
+                    url[package_base.len()..].to_string()
                 } else {
                     panic!("PyPI package isn't stored on base: {:?}", url);
                 }

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -130,7 +130,7 @@ impl SnapshotStorage<SnapshotPath> for Pypi {
                 if url.starts_with(&package_base) {
                     Some(url[package_base.len()..].to_string())
                 } else {
-                    None
+                    panic!("PyPI package isn't stored on base: {:?}", url);
                 }
             })
             .collect();

--- a/src/simple_diff_transfer.rs
+++ b/src/simple_diff_transfer.rs
@@ -42,6 +42,7 @@ pub struct SimpleDiffTransferConfig {
     pub progress: bool,
     pub concurrent_transfer: usize,
     pub no_delete: bool,
+    pub dry_run: bool,
     pub snapshot_config: SnapshotConfig,
     pub print_plan: usize,
 }
@@ -253,6 +254,10 @@ where
             updates.len(),
             deletions.len()
         );
+
+        if self.config.dry_run {
+            return Ok(());
+        }
 
         info!(logger, "updating objects");
 


### PR DESCRIPTION
As bintray is in its end of life, homebrew will soon migrate to other platforms. We should panic when snapshot scans some objects with wrong URL, instead of ignoring it and let it being deleted.