### PR TITLE
test: force metadata from file ext

### DIFF
--- a/src/s3.rs
+++ b/src/s3.rs
@@ -296,6 +296,20 @@ fn get_mime(key: &str) -> Option<String> {
         Some("text/html; charset=utf-8".to_string())
     } else if key.ends_with(".bz2") {
         Some("application/x-bzip2".to_string())
+    } else if key.ends_with(".gz") {
+        Some("application/gzip".to_string())
+    } else if key.ends_with(".lz") {
+        Some("application/x-lzip".to_string())
+    } else if key.ends_with(".lzma") {
+        Some("application/x-lzma".to_string())
+    } else if key.ends_with(".xz") {
+        Some("application/x-xz".to_string())
+    } else if key.ends_with(".zst") {
+        Some("application/zstd".to_string())
+    } else if key.ends_with(".tar") {
+        Some("application/x-tar".to_string())
+    } else if key.ends_with(".zip") {
+        Some("application/zip".to_string())
     } else {
         None
     }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -308,10 +308,10 @@ fn get_mime(key: &str) -> Option<String> {
         Some("application/zstd".to_string())
     } else if key.ends_with(".tar") {
         Some("application/x-tar".to_string())
-    } else if key.ends_with(".zip") || if key.ends_with(".conda") {
+    } else if key.ends_with(".zip") {
         Some("application/zip".to_string())
     } else {
-        None
+        Some("binary/octet-stream".to_string())
     }
 }
 

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -294,6 +294,8 @@ fn get_mime(key: &str) -> Option<String> {
     // TODO: the correct way is to mirror content-type from remote as-is, or to read MIME type
     if key.ends_with(".htm") || key.ends_with(".html") || key.ends_with(".shtml") {
         Some("text/html; charset=utf-8".to_string())
+    } else if key.ends_with(".bz2") {
+        Some("application/x-bzip2".to_string())
     } else {
         None
     }
@@ -317,7 +319,7 @@ where
             mut object,
             length,
             modified_at,
-            content_type,
+            ..
         } = byte_stream;
 
         let body = object.as_stream();
@@ -332,7 +334,7 @@ where
             body: Some(rusoto_s3::StreamingBody::new(body)),
             metadata: Some(metadata),
             content_length: Some(length as i64),
-            content_type: content_type.or_else(|| get_mime(snapshot.key())),
+            content_type: get_mime(snapshot.key()),
             ..Default::default()
         };
 

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -308,7 +308,7 @@ fn get_mime(key: &str) -> Option<String> {
         Some("application/zstd".to_string())
     } else if key.ends_with(".tar") {
         Some("application/x-tar".to_string())
-    } else if key.ends_with(".zip") {
+    } else if key.ends_with(".zip") || if key.ends_with(".conda") {
         Some("application/zip".to_string())
     } else {
         None


### PR DESCRIPTION
This is a hot-fix version for recovering content type from file extension. Should not be used in release version of mirror-docker-unified.