### PR TITLE
pypi: only allow `.whl` to be mirrored

### DIFF
--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -126,6 +126,7 @@ impl SnapshotStorage<SnapshotPath> for Pypi {
         let snapshot = packages?
             .into_iter()
             .flatten()
+            .filter(|(url, _)| url.contains(".whl"))
             .map(|(url, _)| {
                 if url.starts_with(&package_base) {
                     url[package_base.len()..].to_string()


### PR DESCRIPTION
Some pypi packages are deleted, which caused our upstream to respond with an invalid simple index. Therefore, we filter all `.whl` out of the URLs.