### PR TITLE
fix(github-release): release item name can be null

### DIFF
--- a/src/github_release.rs
+++ b/src/github_release.rs
@@ -31,7 +31,6 @@ pub struct GitHubReleaseAsset {
 #[derive(Deserialize, Debug)]
 pub struct GitHubReleaseItem {
     tag_name: String,
-    name: String,
     assets: Vec<GitHubReleaseAsset>,
 }
 


### PR DESCRIPTION
VSCodium stopped syncing several days ago due to a null `name` field. This field is not used anywhere in the codebase so I'm removing it from the schema.

```json
[
    {
        "node_id": "RE_kwDOCJ5IW84Ec3a-",
        "tag_name": "1.70.2.22230",
        "target_commitish": "master",
        "name": null,
        "draft": false,
		...
    },
	...
]
```