### PR TITLE
elan: put lean release in leanprover/lean4

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -339,9 +339,12 @@ fn main() {
                     buffer_path.clone().unwrap(),
                     true,
                 );
+                let lean_org_repo_src = merge_pipe! {
+                    lean4: lean_src,
+                };
                 let unified = merge_pipe! {
                     elan: elan_src,
-                    lean: lean_src,
+                    leanprover: lean_org_repo_src,
                 };
                 let indexed = index_pipe::IndexPipe::new(
                     unified,


### PR DESCRIPTION
cc @PhotonQuantum 

after this PR, please release a new version, and I will bump the docker unified one and change the retain versions to a smaller number.

```
% tree .
.
├── elan
│   ├── mirror_clone_list.html
│   └── releases
│       ├── download
│       │   ├── mirror_clone_list.html
│       │   └── v3.0.0
│       │       ├── elan-aarch64-apple-darwin.tar.gz
│       │       ├── elan-aarch64-unknown-linux-gnu.tar.gz
│       │       ├── elan-x86_64-apple-darwin.tar.gz
│       │       ├── elan-x86_64-pc-windows-msvc.zip
│       │       ├── elan-x86_64-unknown-linux-gnu.tar.gz
│       │       └── mirror_clone_list.html
│       └── mirror_clone_list.html
├── leanprover
│   └── lean4
│       └── releases
│           └── download
│               └── v4.1.0
│                   ├── lean-4.1.0-darwin.tar.zst
│                   ├── lean-4.1.0-darwin.zip
│                   ├── lean-4.1.0-darwin_aarch64.tar.zst
│                   ├── lean-4.1.0-darwin_aarch64.zip
│                   ├── lean-4.1.0-linux.tar.zst
│                   ├── lean-4.1.0-linux.zip
│                   ├── lean-4.1.0-linux_aarch64.tar.zst
│                   └── lean-4.1.0-linux_aarch64.zip
└── mirror_clone_list.html
```