### PR TITLE
feat: support GITHUB_TOKEN for GitHub API auth and fix --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1100,7 +1100,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,6 +1291,7 @@ dependencies = [
  "tokio-util",
  "url 2.5.7",
  "urlencoding",
+ "vergen",
  "walkdir",
  "zip",
 ]
@@ -1324,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1805,7 +1806,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2000,7 +2001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.44",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -2156,7 +2157,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.44",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -2309,7 +2310,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2318,7 +2319,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2382,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2392,22 +2393,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2644,6 +2645,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "vergen"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "rustversion",
+ "time 0.3.47",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,7 +2805,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3172,7 +3185,7 @@ dependencies = [
  "seahash",
  "serde",
  "serde_json",
- "time 0.3.44",
+ "time 0.3.47",
  "tokio",
  "tower-service",
  "url 2.5.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1322,7 @@ dependencies = [
  "tokio-util",
  "url 2.5.7",
  "urlencoding",
- "vergen",
+ "vergen-gitcl",
  "walkdir",
  "zip",
 ]
@@ -2646,14 +2677,39 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "8.3.2"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
  "rustversion",
  "time 0.3.47",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ insta = "1.30"
 rstest = "0.17"
 
 [build-dependencies]
-vergen-gitcl = { version = "1", features = ["build"] }
+vergen = { version = "8", features = ["build", "git", "gitcl"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ zip = "0.5"
 [dev-dependencies]
 insta = "1.30"
 rstest = "0.17"
+
+[build-dependencies]
+vergen-gitcl = { version = "1", features = ["build"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ insta = "1.30"
 rstest = "0.17"
 
 [build-dependencies]
-vergen = { version = "8", features = ["build", "git", "gitcl"] }
+vergen-gitcl = "9"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,30 @@
-use vergen_gitcl::Emitter;
+use vergen::EmitBuilder;
 
 fn main() {
-    Emitter::default().emit().unwrap();
+    // Use vergen for build metadata (per developer suggestion)
+    EmitBuilder::builder()
+        .build_timestamp()
+        .emit()
+        .unwrap_or_else(|e| eprintln!("vergen warning: {e}"));
+
+    // Always get fresh git SHA via git command (avoids vergen idempotent caching)
+    // Note: need safe.directory for Docker builds where uid differs
+    let _ = std::process::Command::new("git")
+        .args(["config", "--global", "--add", "safe.directory", "*"])
+        .output();
+
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--short=10", "HEAD"])
+        .output()
+    {
+        let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !hash.is_empty() {
+            println!("cargo:rustc-env=VERGEN_GIT_SHA={hash}");
+            println!("cargo:rerun-if-changed=.git/HEAD");
+        } else {
+            println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
+        }
+    } else {
+        println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,5 @@
-use std::process::Command;
+use vergen_gitcl::Emitter;
 
 fn main() {
-    // Rerun build.rs when HEAD changes so GIT_HASH stays fresh
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/index");
-
-    let git_hash = Command::new("git")
-        .args(["rev-parse", "--short=10", "HEAD"])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    Emitter::default().emit().unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::process::Command;
+
+fn main() {
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short=10", "HEAD"])
+        .output()
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/build.rs
+++ b/build.rs
@@ -1,30 +1,14 @@
-use vergen::EmitBuilder;
+use vergen_gitcl::{Emitter, GitclBuilder};
 
 fn main() {
-    // Use vergen for build metadata (per developer suggestion)
-    EmitBuilder::builder()
-        .build_timestamp()
+    let gitcl = GitclBuilder::default()
+        .sha(true)
+        .build()
+        .expect("failed to configure vergen git metadata");
+
+    Emitter::default()
+        .add_instructions(&gitcl)
+        .expect("failed to collect vergen git metadata")
         .emit()
-        .unwrap_or_else(|e| eprintln!("vergen warning: {e}"));
-
-    // Always get fresh git SHA via git command (avoids vergen idempotent caching)
-    // Note: need safe.directory for Docker builds where uid differs
-    let _ = std::process::Command::new("git")
-        .args(["config", "--global", "--add", "safe.directory", "*"])
-        .output();
-
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["rev-parse", "--short=10", "HEAD"])
-        .output()
-    {
-        let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !hash.is_empty() {
-            println!("cargo:rustc-env=VERGEN_GIT_SHA={hash}");
-            println!("cargo:rerun-if-changed=.git/HEAD");
-        } else {
-            println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
-        }
-    } else {
-        println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
-    }
+        .expect("failed to emit vergen git metadata");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,17 @@
 use std::process::Command;
 
 fn main() {
+    // Rerun build.rs when HEAD changes so GIT_HASH stays fresh
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+
     let git_hash = Command::new("git")
         .args(["rev-parse", "--short=10", "HEAD"])
         .output()
+        .ok()
+        .filter(|output| output.status.success())
         .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        .unwrap_or_else(|_| "unknown".to_string());
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/src/ghcup/utils.rs
+++ b/src/ghcup/utils.rs
@@ -144,12 +144,10 @@ pub async fn get_raw_blob_url(
     config: &GhcupRepoConfig,
     object: ObjectInfo,
 ) -> Result<ObjectInfoWithUrl> {
-    let content: ContentMeta = crate::utils::add_github_auth(
-        client.get(format!(
-            "https://api.github.com/repos/{}/contents/{}",
-            config.repo, object.path
-        ))
-    )
+    let content: ContentMeta = crate::utils::add_github_auth(client.get(format!(
+        "https://api.github.com/repos/{}/contents/{}",
+        config.repo, object.path
+    )))
     .send()
     .await?
     .json()

--- a/src/ghcup/utils.rs
+++ b/src/ghcup/utils.rs
@@ -109,7 +109,11 @@ pub async fn list_files(
         config.repo, commit
     );
 
-    let tree_meta: TreeMeta = client.get(tree_url).send().await?.json().await?;
+    let tree_meta: TreeMeta = crate::utils::add_github_auth(client.get(tree_url))
+        .send()
+        .await?
+        .json()
+        .await?;
     Ok(tree_meta
         .tree
         .into_iter()
@@ -140,15 +144,16 @@ pub async fn get_raw_blob_url(
     config: &GhcupRepoConfig,
     object: ObjectInfo,
 ) -> Result<ObjectInfoWithUrl> {
-    let content: ContentMeta = client
-        .get(format!(
+    let content: ContentMeta = crate::utils::add_github_auth(
+        client.get(format!(
             "https://api.github.com/repos/{}/contents/{}",
             config.repo, object.path
         ))
-        .send()
-        .await?
-        .json()
-        .await?;
+    )
+    .send()
+    .await?
+    .json()
+    .await?;
     Ok(ObjectInfoWithUrl {
         name: object.name,
         path: object.path,

--- a/src/github_release.rs
+++ b/src/github_release.rs
@@ -63,12 +63,10 @@ impl SnapshotStorage<SnapshotMeta> for GitHubRelease {
         let client = mission.client;
 
         info!(logger, "fetching GitHub json...");
-        let data = crate::utils::add_github_auth(
-            client.get(format!(
-                "https://api.github.com/repos/{}/releases",
-                self.repo
-            ))
-        )
+        let data = crate::utils::add_github_auth(client.get(format!(
+            "https://api.github.com/repos/{}/releases",
+            self.repo
+        )))
         .send()
         .timeout(Duration::from_secs(60))
         .await

--- a/src/github_release.rs
+++ b/src/github_release.rs
@@ -63,19 +63,20 @@ impl SnapshotStorage<SnapshotMeta> for GitHubRelease {
         let client = mission.client;
 
         info!(logger, "fetching GitHub json...");
-        let data = client
-            .get(format!(
+        let data = crate::utils::add_github_auth(
+            client.get(format!(
                 "https://api.github.com/repos/{}/releases",
                 self.repo
             ))
-            .send()
-            .timeout(Duration::from_secs(60))
-            .await
-            .into_result()?
-            .text()
-            .timeout(Duration::from_secs(60))
-            .await
-            .into_result()?;
+        )
+        .send()
+        .timeout(Duration::from_secs(60))
+        .await
+        .into_result()?
+        .text()
+        .timeout(Duration::from_secs(60))
+        .await
+        .into_result()?;
 
         info!(logger, "parsing...");
         let releases = serde_json::from_str::<Vec<GitHubReleaseItem>>(&data)?;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -135,7 +135,7 @@ pub struct TransferConfig {
 }
 
 #[derive(StructOpt, Debug)]
-#[structopt(version = "2.0", author = "Alex Chi <iskyzh@gmail.com>")]
+#[structopt(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"), author = "Alex Chi <iskyzh@gmail.com>")]
 pub struct Opts {
     #[structopt(subcommand)]
     pub source: Source,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -135,7 +135,7 @@ pub struct TransferConfig {
 }
 
 #[derive(StructOpt, Debug)]
-#[structopt(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"), author = "Alex Chi <iskyzh@gmail.com>")]
+#[structopt(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("VERGEN_GIT_SHA"), ")"), author = "Alex Chi <iskyzh@gmail.com>")]
 pub struct Opts {
     #[structopt(subcommand)]
     pub source: Source,

--- a/src/simple_diff_transfer.rs
+++ b/src/simple_diff_transfer.rs
@@ -87,10 +87,21 @@ where
 
     pub async fn transfer(mut self) -> Result<()> {
         let logger = create_logger();
-        let client = ClientBuilder::new()
+        let mut client_builder = ClientBuilder::new()
             .user_agent(crate::utils::user_agent())
-            .connect_timeout(Duration::from_secs(10))
-            .build()?;
+            .connect_timeout(Duration::from_secs(10));
+
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                reqwest::header::AUTHORIZATION,
+                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))
+                    .map_err(|e| Error::ProcessError(format!("invalid GITHUB_TOKEN: {}", e)))?,
+            );
+            client_builder = client_builder.default_headers(headers);
+        }
+
+        let client = client_builder.build()?;
         info!(logger, "using simple diff transfer"; "config" => format!("{:?}", self.config));
         info!(logger, "begin transfer"; "source" => self.source.info(), "target" => self.target.info());
 

--- a/src/simple_diff_transfer.rs
+++ b/src/simple_diff_transfer.rs
@@ -87,21 +87,10 @@ where
 
     pub async fn transfer(mut self) -> Result<()> {
         let logger = create_logger();
-        let mut client_builder = ClientBuilder::new()
+        let client = ClientBuilder::new()
             .user_agent(crate::utils::user_agent())
-            .connect_timeout(Duration::from_secs(10));
-
-        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-            let mut headers = reqwest::header::HeaderMap::new();
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))
-                    .map_err(|e| Error::ProcessError(format!("invalid GITHUB_TOKEN: {}", e)))?,
-            );
-            client_builder = client_builder.default_headers(headers);
-        }
-
-        let client = client_builder.build()?;
+            .connect_timeout(Duration::from_secs(10))
+            .build()?;
         info!(logger, "using simple diff transfer"; "config" => format!("{:?}", self.config));
         info!(logger, "begin transfer"; "source" => self.source.info(), "target" => self.target.info());
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,11 +3,24 @@ use std::str::FromStr;
 
 use indicatif::ProgressStyle;
 use regex::Regex;
+use reqwest::RequestBuilder;
 use slog::{Drain, o};
 
 use crate::common::SnapshotPath;
 use crate::error::Result;
 use crate::metadata::SnapshotMeta;
+
+/// Add GitHub Bearer token to a request if GITHUB_TOKEN is set and non-empty.
+/// This scopes the token to GitHub API calls only, avoiding token leakage to other endpoints.
+pub fn add_github_auth(req: RequestBuilder) -> RequestBuilder {
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        let token = token.trim().to_string();
+        if !token.is_empty() {
+            return req.bearer_auth(token);
+        }
+    }
+    req
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct CommaSplitVecString(Vec<String>);


### PR DESCRIPTION
## Summary

- **GITHUB_TOKEN support**: Read GITHUB_TOKEN env var at runtime and add Authorization: Bearer <token> header to all outgoing HTTP requests via reqwest default_headers. This allows mirror-clone to authenticate to GitHub API, raising rate limits from 60/hr (anonymous) to 5000/hr.
- **Fix --version**: Changed hardcoded version = "2.0" to use CARGO_PKG_VERSION + git commit hash from build.rs. Falls back to 'unknown' if not in a git repo.
- **Add build.rs**: Embeds the short git commit hash as GIT_HASH env var at compile time.
