### PR TITLE
fix(s3): use required-only request checksums

### DIFF
--- a/src/s3.rs
+++ b/src/s3.rs
@@ -24,7 +24,11 @@ use crate::stream_pipe::ByteStream;
 use crate::traits::{Key, SnapshotStorage, TargetStorage};
 
 use async_trait::async_trait;
-use aws_sdk_s3::{Client as S3Client, config::Region, primitives::ByteStream as S3ByteStream};
+use aws_sdk_s3::{
+    Client as S3Client,
+    config::{Region, RequestChecksumCalculation},
+    primitives::ByteStream as S3ByteStream,
+};
 use futures_util::{StreamExt, stream};
 use slog::{debug, info, warn};
 
@@ -63,6 +67,8 @@ impl S3Backend {
             .region(Region::new("jCloud S3"))
             .endpoint_url(config.endpoint.clone())
             .force_path_style(true)
+            // Avoid AWS-chunked trailers unsupported by jCloud S3.
+            .request_checksum_calculation(RequestChecksumCalculation::WhenRequired)
             .build();
         let client = S3Client::from_conf(s3_config);
         Self { config, client }


### PR DESCRIPTION
The AWS SDK migration in v0.2.42 changed S3 `PutObject` requests to calculate optional CRC32 checksums by default. The SDK sends those checksums using AWS-chunked encoding and a trailing checksum.

jCloud S3 does not handle that request format correctly and rejects uploads with:

```
XAmzContentSHA256Mismatch
```

This affects normal payloads and generated `mirror_clone_list.html` files. Because the transfer loop currently logs individual PUT failures and continues, a job can emit thousands of full SDK errors and still end with `transfer complete`.

The fix here sets `.request_checksum_calculation(RequestChecksumCalculation::WhenRequired)` to work around this limit on latest S3 API.
