### PR TITLE
fix(pypa-index): escape for href tag `requires-python`

### DIFF
--- a/crates/pypa-simple/src/lib.rs
+++ b/crates/pypa-simple/src/lib.rs
@@ -475,18 +475,18 @@ fn parse_anchors(document: &str) -> Vec<HtmlAnchor> {
                 return None;
             }
             let attributes = tag.attributes();
-            let href = attributes
-                .get("href")
-                .flatten()
-                .map(|value| value.as_utf8_str().into_owned())?;
+            let href = attributes.get("href").flatten().map(|value| {
+                let value = value.as_utf8_str();
+                html_escape::decode_html_entities(&value).into_owned()
+            })?;
             let attrs = attributes
                 .iter()
                 .filter(|(name, _)| name.as_ref() != "href")
                 .map(|(name, value)| {
-                    (
-                        name.as_ref().to_ascii_lowercase(),
-                        value.as_ref().map(|value| value.clone().into_owned()),
-                    )
+                    let value = value
+                        .as_ref()
+                        .map(|value| html_escape::decode_html_entities(value).into_owned());
+                    (name.as_ref().to_ascii_lowercase(), value)
                 })
                 .collect();
             Some(HtmlAnchor {
@@ -637,6 +637,33 @@ mod tests {
             "https://pypi.example/nvidia-cublas/nvidia_cublas-1.0.whl"
         );
         assert_eq!(project.files[0].hashes["sha256"], "abc");
+    }
+
+    #[test]
+    fn decodes_html_attribute_entities_before_rendering() {
+        let url = Url::parse("https://pypi.example/demo/").unwrap();
+        let page = parse_page(
+            &url,
+            br#"<a href="demo-1.0.whl?download=1&amp;mirror=1#sha256=abc" data-requires-python="&gt;=3.8" data-yanked="use &quot;new&quot;">demo-1.0.whl</a>"#,
+            Some("demo"),
+        )
+        .unwrap();
+        let ParsedPage::Project(project) = page else {
+            panic!("expected project");
+        };
+        assert_eq!(project.files[0].requires_python.as_deref(), Some(">=3.8"));
+        assert_eq!(project.files[0].yanked.as_deref(), Some("use \"new\""));
+        assert_eq!(
+            project.files[0].url,
+            "https://pypi.example/demo/demo-1.0.whl?download=1&mirror=1"
+        );
+
+        let rendered = render_project(&project).unwrap();
+        assert!(rendered.html.contains(r#"data-requires-python="&gt;=3.8""#));
+        assert!(!rendered.html.contains("&amp;gt;=3.8"));
+        let json: Value = serde_json::from_str(&rendered.json).unwrap();
+        assert_eq!(json["files"][0]["requires-python"], ">=3.8");
+        assert_eq!(json["files"][0]["yanked"], "use \"new\"");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The generated `pytorch-wheels` PyPA Simple indexes corrupt HTML-encoded `requires-python` values while parsing and re-rendering upstream PyTorch index pages.

Upstream PyTorch HTML:

```html
data-requires-python="&gt;=3.10"
```

Our generated HTML:

```html
data-requires-python="&amp;gt;=3.10"
```

Our generated JSON:

```json
"requires-python": "&gt;=3.10"
```

After one HTML decoding pass, clients receive the literal string `&gt;=3.10` rather than `>=3.10`. This is not a valid Python version specifier.

For the live `filelock` index, all 170 entries carrying `requires-python` were affected.

### Reproduction

Create a temporary project:

```toml
[project]
name = "pytorch-rewrite-check"
version = "0.0.0"
requires-python = ">=3.11"
dependencies = ["filelock==3.29.7"]
```

Run:

```bash
RUST_LOG=uv=debug uv lock -vv \
  --dry-run \
  --no-cache \
  --no-config \
  --default-index https://mirror.sjtu.edu.cn/pytorch-wheels/cpu/
```

Observed output:

```text
Skipping file for filelock: Failed to parse `requires-python`: `&gt;=3.10`
...
Because there is no version of filelock==3.29.7 ...
```

The version exists in the generated index, but `uv` discards it because its `requires-python` value is malformed.

### Root cause

`crates/pypa-simple/src/lib.rs::parse_anchors` reads HTML attribute values from `tl` without decoding character references. `render_project` then HTML-escapes those already encoded strings again.

This affects `data-requires-python`, `data-yanked` reasons and query strings in `href` HTML tag.

The correct behavior is to decode HTML entities once when importing attributes into the internal model, then escape them once when serializing HTML.

### Other routes

- `astral-wheels` currently receives JSON-origin metadata and is unaffected in tested indexes: 8/8 `requires-python` values were valid `>=3.10`. The parser fix should nevertheless cover any HTML-origin Astral pages.
- `/pypi/web/simple` proxies upstream HTML without parsing/re-rendering it and preserves `requires-python` correctly.
- `/pypi-packages` is an artifact route, not an index, and does not itself carry `requires-python`.